### PR TITLE
remove gtest_main and gmock_main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,7 @@ target_link_libraries( ArmyChess
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::HttpServer
     gtest
-    gtest_main
-    gmock_main
+    gmock
 )
 
 add_test(NAME ArmyChess COMMAND ArmyChess)


### PR DESCRIPTION
## Why need this change? / Root cause:
- remove gtest_main and gmock_main
## Changes made:
-
## Test Scope / Change impact: 
-
